### PR TITLE
is-a and is-not-a highlight

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -30,7 +30,7 @@
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(from|contains|only|obeys|includes|or|and|required|preferred|extensible|MS|SU)\\b"
+					"match": "\\b(from|contains|only|obeys|includes|or|and|required|preferred|extensible|MS|SU|is-a|is-not-a)\\b"
 				},
 				{
 					"name": "keyword.tokens.fsh",


### PR DESCRIPTION
Adds `is-a` and `is-not-a` as reserved keywords to be highlighted.