### PR TITLE
Add Usage and named keywords

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -26,11 +26,11 @@
 			"patterns": [
 				{
 					"name": "keyword.control.fsh",
-					"match": "\\b(Profile|Extension|SimpleElement|ComplexElement|Parent|Mixin|Mixins|Id|Title|Description|Datatype|Property|Element|Abstract|Entry|Group|Rules|Instance|InstanceOf|Invariant|Expression|Severity|XPath|Mapping|Source|Target|Metadata|Slice|ValueSet|Language|Alias)\\b"
+					"match": "\\b(Profile|Extension|SimpleElement|ComplexElement|Parent|Mixin|Mixins|Id|Title|Description|Datatype|Property|Element|Abstract|Entry|Group|Rules|Instance|InstanceOf|Invariant|Expression|Severity|XPath|Mapping|Source|Target|Metadata|Slice|ValueSet|Language|Alias|Usage)\\b"
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(from|contains|only|obeys|includes|or|and|required|preferred|extensible|MS|SU|is-a|is-not-a)\\b"
+					"match": "\\b(from|contains|only|obeys|includes|or|and|required|preferred|extensible|MS|SU|is-a|is-not-a|named)\\b"
 				},
 				{
 					"name": "keyword.tokens.fsh",


### PR DESCRIPTION
Adds `Usage` and `named` as keywords to support new FSH syntax recently added.