### PR TITLE
Updated Keywords

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -26,15 +26,19 @@
 			"patterns": [
 				{
 					"name": "keyword.control.fsh",
-					"match": "\\b(Alias|CodeSystem|Expression|Extension|Description|Id|Instance|InstanceOf|Invariant|Mapping|Mixins|Parent|Profile|RuleSet|Severity|Source|Target|Title|Usage|ValueSet|XPath)(?=:)\\b"
+					"match": "\\b(Alias|CodeSystem|Expression|Extension|Description|Id|Instance|InstanceOf|Invariant|Mapping|Mixins|Parent|Profile|RuleSet|Severity|Source|Target|Title|Usage|ValueSet|XPath)(?=\\s*:)\\b"
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(and|codes|contains|example|exclude|extensible|from|includes|is-a|is-not-a|named|obeys|only|or|preferred|system|required|units|valueset|where|D|MS|N|SU|TU)\\b"
+					"match": "\\b(?<=\\s)(and|codes|contains|exclude|from|includes|is-a|is-not-a|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)(?=\\s)\\b"
+				},
+				{
+					"name": "keyword.reserved.fsh",
+					"match": "(\\(\\s*)(example|extensible|preferred|required)(\\s*\\))"
 				},
 				{
 					"name": "keyword.tokens.fsh",
-					"match": "\\?!|\\*|->|=|:"
+					"match": "\\*|->|:=|=|:"
 				}
 			]
 		},

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -26,15 +26,15 @@
 			"patterns": [
 				{
 					"name": "keyword.control.fsh",
-					"match": "\\b(Profile|Extension|SimpleElement|ComplexElement|Parent|Mixin|Mixins|Id|Title|Description|Datatype|Property|Element|Abstract|Entry|Group|Rules|Instance|InstanceOf|Invariant|Expression|Severity|XPath|Mapping|Source|Target|Metadata|Slice|ValueSet|Language|Alias|Usage)\\b"
+					"match": "\\b(Alias|CodeSystem|Expression|Extension|Description|Id|Instance|InstanceOf|Invariant|Mapping|Mixins|Parent|Profile|RuleSet|Severity|Source|Target|Title|Usage|ValueSet|XPath)(?=:)\\b"
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(from|contains|only|obeys|includes|or|and|required|preferred|extensible|MS|SU|is-a|is-not-a|named)\\b"
+					"match": "\\b(and|codes|contains|example|exclude|extensible|from|includes|is-a|is-not-a|named|obeys|only|or|preferred|system|required|units|valueset|where|D|MS|N|SU|TU)\\b"
 				},
 				{
 					"name": "keyword.tokens.fsh",
-					"match": "\\?!|\\*"
+					"match": "\\?!|\\*|->|=|:"
 				}
 			]
 		},


### PR DESCRIPTION
Updated various keywords in the extension to match the keywords we have in the grammar as of today, which includes anything in the latest release (`v0.10.0`) and mappings and new flags that are being added this sprint.

I removed keywords that were in the list that are not in the FSH grammar as of now and that Mark confirmed are not keywords in FSH. I also added in keywords that were missing from the extension but are in the grammar and added in a few symbols from the grammar, including `:`, `=`, and `->`.