### PR TITLE
Update pattern/fixed value keywords

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -34,11 +34,11 @@
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "(\\(\\s*)(example|extensible|preferred|required)(\\s*\\))"
+					"match": "(\\(\\s*)(exactly|example|extensible|preferred|required)(\\s*\\))"
 				},
 				{
 					"name": "keyword.tokens.fsh",
-					"match": "\\*|->|:=|=|:"
+					"match": "\\*|->|=|:"
 				}
 			]
 		},


### PR DESCRIPTION
Added "exactly" as a keyword that will match within parentheses as this is the new approach for specifying fixed values.

Removed `:=` for consistency in the code, although both of these characters will highlight individually still so it will not look much different in practice in the extension.