### PR TITLE
Fix highlighting of quoted codes

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -30,7 +30,7 @@
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(?<=\\s)(and|codes|contains|exclude|from|include|is-a|is-not-a|descendent-of|regex|in|not-in|generalizes|exists|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)(?=\\s)\\b"
+					"match": "\\b(?<=\\s)(and|codes|contains|descendent-of|exclude|exists|from|generalizes|include|in|insert|is-a|is-not-a|named|not-in|obeys|only|or|regex|system|units|valueset|where|D|MS|N|SU|TU|\\?!)(?=\\s)\\b"
 				},
 				{
 					"name": "keyword.reserved.fsh",

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -30,7 +30,7 @@
 				},
 				{
 					"name": "keyword.reserved.fsh",
-					"match": "\\b(?<=\\s)(and|codes|contains|exclude|from|includes|is-a|is-not-a|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)(?=\\s)\\b"
+					"match": "\\b(?<=\\s)(and|codes|contains|exclude|from|include|is-a|is-not-a|descendent-of|regex|in|not-in|generalizes|exists|named|obeys|only|or|system|units|valueset|where|D|MS|N|SU|TU|\\?!)(?=\\s)\\b"
 				},
 				{
 					"name": "keyword.reserved.fsh",
@@ -77,7 +77,11 @@
 		"codes": {
 			"patterns": [ 
 				{
-					"name": "constant.numeric.fsh",
+					"name": "constant.numeric.quoted.code.fsh",
+					"match": "#\"(?:\\\\.|[^\\\\\"])*\""
+				},
+				{
+					"name": "constant.numeric.code.fsh",
 					"match": "#[^\\s]*"
 				}
 			]


### PR DESCRIPTION
Fixes #8 by adding a regular expression to handle the highlighting of quoted codes.

Also fixes keyword highlighting for several of the ValueSet filter keywords, and the `include` keyword.