### PR TITLE
1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-language-fsh",
-    "version": "1.0.6",
+    "version": "1.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-language-fsh",
     "displayName": "vscode-language-fsh",
     "description": "VSCode FHIR Shorthand (FSH) Language Support",
-    "version": "1.0.6",
+    "version": "1.2.0",
     "author": "The MITRE Corporation",
     "license": "Apache-2.0",
     "publisher": "kmahalingam",


### PR DESCRIPTION
I'm not sure what happened w/ 1.1.0.  We have 1.1.0 published in the marketplace but it looks like the `package.json` w/ version `1.1.0` never got commit.  But the 1.1.0 feature (snippets) is definitely in there.  So I think we just forgot to commit the package.json last time.  And by "we", I mean "I".

This should only need one token reviewer.