### PR TITLE
Update vscode testing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,12 @@
             "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
             "dev": true
         },
+        "@types/vscode": {
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.39.0.tgz",
+            "integrity": "sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==",
+            "dev": true
+        },
         "@typescript-eslint/eslint-plugin": {
             "version": "4.16.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz",
@@ -266,6 +272,18 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "@vscode/test-electron": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+            "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
         },
         "acorn": {
             "version": "7.4.1",
@@ -436,12 +454,6 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
-        },
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
@@ -577,12 +589,6 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
-        "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -676,21 +682,6 @@
             "dev": true,
             "requires": {
                 "ansi-colors": "^4.1.1"
-            }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "^4.0.3"
             }
         },
         "escalade": {
@@ -1764,12 +1755,6 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
-        "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
-        },
         "serialize-javascript": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -1841,22 +1826,6 @@
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 }
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
-        },
-        "source-map-support": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "sprintf-js": {
@@ -2048,141 +2017,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
             "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
             "dev": true
-        },
-        "vscode": {
-            "version": "1.1.37",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-            "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "mocha": "^5.2.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "vscode-test": "^0.4.1"
-            },
-            "dependencies": {
-                "agent-base": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-                    "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-                    "dev": true,
-                    "requires": {
-                        "es6-promisify": "^5.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "diff": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-                    "dev": true
-                },
-                "he": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "mocha": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-                    "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-                    "dev": true,
-                    "requires": {
-                        "browser-stdout": "1.3.1",
-                        "commander": "2.15.1",
-                        "debug": "3.1.0",
-                        "diff": "3.5.0",
-                        "escape-string-regexp": "1.0.5",
-                        "glob": "7.1.2",
-                        "growl": "1.10.5",
-                        "he": "1.1.1",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "supports-color": "5.4.0"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "7.1.2",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                            "dev": true,
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                },
-                "vscode-test": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-                    "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-                    "dev": true,
-                    "requires": {
-                        "http-proxy-agent": "^2.1.0",
-                        "https-proxy-agent": "^2.2.1"
-                    },
-                    "dependencies": {
-                        "http-proxy-agent": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-                            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-                            "dev": true,
-                            "requires": {
-                                "agent-base": "4",
-                                "debug": "3.1.0"
-                            }
-                        },
-                        "https-proxy-agent": {
-                            "version": "2.2.4",
-                            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-                            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-                            "dev": true,
-                            "requires": {
-                                "agent-base": "^4.3.0",
-                                "debug": "^3.1.0"
-                            }
-                        }
-                    }
-                }
-            }
         },
         "vscode-test": {
             "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
         "pretest": "npm run build",
         "test": "node ./out/test/runTest.js",
         "check": "npm run lint && npm run prettier && npm run test",
-        "vscode:prepublish": "tsc -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "vscode:prepublish": "tsc -p ./"
     },
     "devDependencies": {
         "@types/antlr4": "^4.7.2",
@@ -85,8 +84,10 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.1",
         "@types/node": "^14.14.25",
+        "@types/vscode": "^1.39.0",
         "@typescript-eslint/eslint-plugin": "^4.16.1",
         "@typescript-eslint/parser": "^4.16.1",
+        "@vscode/test-electron": "^1.6.2",
         "chai": "^4.3.4",
         "chai-spies": "^1.0.0",
         "eslint": "^7.21.0",
@@ -97,7 +98,6 @@
         "nock": "^13.0.11",
         "prettier": "^2.2.1",
         "typescript": "^4.2.2",
-        "vscode": "^1.1.37",
         "vscode-test": "^1.5.1"
     },
     "dependencies": {


### PR DESCRIPTION
There was only one vulnerability reported in this repo, and it came from the [vscode](https://www.npmjs.com/package/vscode) devDependency. However, it turns out that [vscode is deprecated](https://github.com/Microsoft/vscode-extension-vscode#%EF%B8%8F-deprecated-use-typesvscode-and-vscode-test-instead-%EF%B8%8F). I followed the [migration instructions](https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode) provided to replace it. However, we had all the scripts set up already, so I just installed the new dependencies and removed the `postinstall` script as specified.

I removed `node_modules`, reinstalled, and re-ran the tests and everything seems to be working appropriately. If I missed testing anything, let me know.