### PR TITLE
To 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-language-fsh",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-language-fsh",
   "displayName": "FHIR Shorthand",
   "description": "FHIR Shorthand (FSH) Language Support by MITRE",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "The MITRE Corporation",
   "license": "Apache-2.0",
   "publisher": "MITRE-Health",


### PR DESCRIPTION
Update `displayName` and `description`. Test out that running `vsce package` and then installing with `vsix` updates your local package to have the expected `displayName` and `description`.