### PR TITLE
Provide autocompletion for paths when writing rules

### DIFF
--- a/src/FshCompletionProvider.ts
+++ b/src/FshCompletionProvider.ts
@@ -505,6 +505,23 @@ export class FshCompletionProvider implements CompletionItemProvider {
             types: element.type?.map((type: any) => type.code) ?? [],
             children: []
           });
+          // if this represents a choice element, add the choices in as additional elements
+          // choice elements have a path that ends in [x], and the choices represent the available types.
+          if (pathParts[0].endsWith('[x]') && element.type?.length > 0) {
+            const basePathPart = pathParts[0].slice(0, -3);
+            parent.push(
+              ...element.type.map(
+                (availableType: any) =>
+                  ({
+                    path: `${basePathPart}${availableType.code?.[0].toLocaleUpperCase()}${availableType.code?.slice(
+                      1
+                    )}`,
+                    types: [availableType?.code],
+                    children: []
+                  } as ElementInfo)
+              )
+            );
+          }
         }
       }
     });

--- a/src/FshDefinitionProvider.ts
+++ b/src/FshDefinitionProvider.ts
@@ -345,12 +345,3 @@ function getInstanceOfFromMetadata(metadata: { instanceOf: () => any }[]): strin
     }
   }
 }
-
-// function getUsefulMetadata(
-//   rules: MetadataField[],
-//   metadata: { [key in MetadataField]?: () => any }[]
-// ): { [key in MetadataField]?: string } {
-//   const result: ReturnType<typeof getUsefulMetadata> = {};
-
-//   return result;
-// }

--- a/src/test/fixtures/instances.fsh
+++ b/src/test/fixtures/instances.fsh
@@ -1,0 +1,7 @@
+// This is the file that contains instances.
+// Just one instance so far, but that's okay.
+
+Instance: ThisOneObservation
+InstanceOf: Observation
+* status = #final
+* code = #very-good

--- a/src/test/suite/FshCompletionProvider.test.ts
+++ b/src/test/suite/FshCompletionProvider.test.ts
@@ -1362,6 +1362,114 @@ suite('FshCompletionProvider', () => {
       assert.deepEqual(elements, expectedElements);
     });
 
+    test('should build elements from a snapshot with choice elements', () => {
+      const snapshot: any[] = [
+        {
+          path: 'Observation'
+        },
+        {
+          path: 'Observation.value[x]',
+          type: [
+            { code: 'Quantity' },
+            { code: 'CodeableConcept' },
+            { code: 'string' },
+            { code: 'boolean' },
+            { code: 'integer' },
+            { code: 'Range' },
+            { code: 'Ratio' },
+            { code: 'SampledData' },
+            { code: 'time' },
+            { code: 'dateTime' },
+            { code: 'Period' },
+            { code: 'Attachment' }
+          ]
+        }
+      ];
+      const elements = instance.buildElementsFromSnapshot(snapshot);
+      assert.lengthOf(elements, 13);
+      const expectedElements: ElementInfo[] = [
+        {
+          path: 'value[x]',
+          types: [
+            'Quantity',
+            'CodeableConcept',
+            'string',
+            'boolean',
+            'integer',
+            'Range',
+            'Ratio',
+            'SampledData',
+            'time',
+            'dateTime',
+            'Period',
+            'Attachment'
+          ],
+          children: []
+        },
+        {
+          path: 'valueQuantity',
+          types: ['Quantity'],
+          children: []
+        },
+        {
+          path: 'valueCodeableConcept',
+          types: ['CodeableConcept'],
+          children: []
+        },
+        {
+          path: 'valueString',
+          types: ['string'],
+          children: []
+        },
+        {
+          path: 'valueBoolean',
+          types: ['boolean'],
+          children: []
+        },
+        {
+          path: 'valueInteger',
+          types: ['integer'],
+          children: []
+        },
+        {
+          path: 'valueRange',
+          types: ['Range'],
+          children: []
+        },
+        {
+          path: 'valueRatio',
+          types: ['Ratio'],
+          children: []
+        },
+        {
+          path: 'valueSampledData',
+          types: ['SampledData'],
+          children: []
+        },
+        {
+          path: 'valueTime',
+          types: ['time'],
+          children: []
+        },
+        {
+          path: 'valueDateTime',
+          types: ['dateTime'],
+          children: []
+        },
+        {
+          path: 'valuePeriod',
+          types: ['Period'],
+          children: []
+        },
+        {
+          path: 'valueAttachment',
+          types: ['Attachment'],
+          children: []
+        }
+      ];
+      assert.deepEqual(elements, expectedElements);
+    });
+
     test('should return an empty list if none of the snapshot elements have paths', () => {
       // this should never happen unless the input is very unusual
       const snapshot: any[] = [{ id: 'Unusual' }, { id: 'Unusual.element' }];

--- a/src/test/suite/FshCompletionProvider.test.ts
+++ b/src/test/suite/FshCompletionProvider.test.ts
@@ -747,6 +747,48 @@ suite('FshCompletionProvider', () => {
     });
   });
 
+  suite('#getPathItems', () => {
+    // we'll use a partial list of paths from Patient
+    const patientBasePaths = [
+      'Patient',
+      'Patient.id',
+      'Patient.name',
+      'Patient.name.given',
+      'Patient.name.family',
+      'Patient.photo',
+      'Patient.contact',
+      'Patient.contact.relationship',
+      'Patient.contact.name',
+      'Patient.contact.name.given',
+      'Patient.contact.name.family'
+    ];
+
+    test('should get path items that could appear as the first part of the path', () => {
+      const result = instance.getPathItems([], patientBasePaths);
+      assert.lengthOf(result, 4);
+      assert.includeDeepMembers(result, [
+        new vscode.CompletionItem('id'),
+        new vscode.CompletionItem('name'),
+        new vscode.CompletionItem('photo'),
+        new vscode.CompletionItem('contact')
+      ]);
+    });
+
+    test('should get path items that could appear after an existing path segment', () => {
+      const result = instance.getPathItems(['contact'], patientBasePaths);
+      assert.lengthOf(result, 2);
+      assert.includeDeepMembers(result, [
+        new vscode.CompletionItem('relationship'),
+        new vscode.CompletionItem('name')
+      ]);
+    });
+
+    test('should get no items when the existing path segments are not present', () => {
+      const result = instance.getPathItems(['con'], patientBasePaths);
+      assert.lengthOf(result, 0);
+    });
+  });
+
   suite('#updateFhirEntities', () => {
     const defaultConfig = [
       'id: cookie.mountain',

--- a/src/test/suite/FshDefinitionProvider.test.ts
+++ b/src/test/suite/FshDefinitionProvider.test.ts
@@ -41,7 +41,7 @@ suite('FshDefinitionProvider', () => {
 
   suite('#scanAll', () => {
     test('should have an entry in fileNames for each file path', () => {
-      assert.equal(instance.fileNames.size, 10);
+      assert.equal(instance.fileNames.size, 11);
 
       assert.containsAllKeys(instance.fileNames, [
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'profiles', 'profiles1.fsh'),
@@ -49,6 +49,7 @@ suite('FshDefinitionProvider', () => {
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'aliases.fsh'),
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'codesystems.fsh'),
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'extensions.fsh'),
+        path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'instances.fsh'),
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'invariants.fsh'),
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'rulesets.fsh'),
         path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'valuesets.fsh'),
@@ -121,7 +122,7 @@ suite('FshDefinitionProvider', () => {
     });
 
     test('should have an entry in nameInformation for each name', () => {
-      assert.equal(instance.nameInformation.size, 18);
+      assert.equal(instance.nameInformation.size, 19);
       assert.containsAllKeys(instance.nameInformation, [
         'MyObservation',
         'MyPatient',
@@ -132,6 +133,7 @@ suite('FshDefinitionProvider', () => {
         'MyCodeSystem',
         'AnotherCodeSystem',
         'IceCreamExtension',
+        'ThisOneObservation',
         'inv-1',
         'inv-2',
         'ext-1',
@@ -154,11 +156,34 @@ suite('FshDefinitionProvider', () => {
             new vscode.Position(74, 0)
           ),
           type: 'CodeSystem',
-          id: 'another-code-system'
+          id: 'another-code-system',
+          parent: undefined,
+          instanceOf: undefined
         }
       ];
       assert.sameDeepMembers(
         instance.nameInformation.get('AnotherCodeSystem'),
+        expectedInformation
+      );
+    });
+
+    test('should have all information stored for a name with instanceOf', () => {
+      const expectedInformation: NameInfo[] = [
+        {
+          location: new vscode.Location(
+            vscode.Uri.file(
+              path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'instances.fsh')
+            ),
+            new vscode.Position(3, 0)
+          ),
+          type: 'Instance',
+          id: undefined,
+          parent: undefined,
+          instanceOf: 'Observation'
+        }
+      ];
+      assert.sameDeepMembers(
+        instance.nameInformation.get('ThisOneObservation'),
         expectedInformation
       );
     });
@@ -177,7 +202,9 @@ suite('FshDefinitionProvider', () => {
             new vscode.Position(9, 0)
           ),
           type: 'Profile',
-          id: 'reused-observation'
+          id: 'reused-observation',
+          parent: 'Observation',
+          instanceOf: undefined
         },
         {
           location: new vscode.Location(
@@ -187,7 +214,9 @@ suite('FshDefinitionProvider', () => {
             new vscode.Position(9, 0)
           ),
           type: 'ValueSet',
-          id: 'reused-values'
+          id: 'reused-values',
+          parent: undefined,
+          instanceOf: undefined
         }
       ];
       assert.sameDeepMembers(instance.nameInformation.get('ReusedName'), expectedInformation);
@@ -220,14 +249,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(0, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       assert.sameDeepMembers(instance.nameInformation.get('ParamRuleSet'), [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(3, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
     });
@@ -248,14 +281,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(0, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       assert.sameDeepMembers(instance.nameInformation.get('ParamRuleSet'), [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(3, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
     });
@@ -277,14 +314,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(0, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       assert.sameDeepMembers(instance.nameInformation.get('ParamRuleSet'), [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(3, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
     });
@@ -299,14 +340,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(5, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       instance.nameInformation.set('ParamRuleSet', [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(10, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       // update from one file
@@ -316,14 +361,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(0, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       assert.sameDeepMembers(instance.nameInformation.get('ParamRuleSet'), [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(3, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
     });
@@ -338,14 +387,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(5, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       instance.nameInformation.set('ParamRuleSet', [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(10, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       // try to update from one file,
@@ -361,14 +414,18 @@ suite('FshDefinitionProvider', () => {
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(5, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
       assert.sameDeepMembers(instance.nameInformation.get('ParamRuleSet'), [
         {
           location: new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(10, 0)),
           type: 'RuleSet',
-          id: undefined
+          id: undefined,
+          parent: undefined,
+          instanceOf: undefined
         }
       ]);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,21 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": ["es6"],                        /* Specify library files to be included in the compilation. */
-    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es6",
+      "ES2019.Array",
+      "DOM"
+    ] /* Specify library files to be included in the compilation. */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                        /* Generates corresponding '.map' file. */
+    "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "out",                         /* Redirect output structure to the directory. */
+    "outDir": "out" /* Redirect output structure to the directory. */,
     // "rootDir": "src",                      /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -24,7 +28,7 @@
 
     /* Strict Type-Checking Options */
     // "strict": true,                        /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -39,19 +43,20 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
-    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
       "*": [
-          "node_modules/*" //,
-          // "src/types/*"
+        "node_modules/*" //,
+        // "src/types/*"
       ]
     },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -66,8 +71,5 @@
     /* Advanced Options */
     // "resolveJsonModule": true              /* Include modules imported with '.json' extension */
   },
-  "exclude": [
-    "node_modules",
-    "out"
-  ]
+  "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
Completes task [CIMPL-337](https://standardhealthrecord.atlassian.net/browse/CIMPL-337).

When writing a rule in a Profile, Extension, Logical, or Resource, the paths of existing elements can be determined from FHIR entity definitions in the project's dependencies. Provide these paths as autocompletion options when writing rules.

It sounds pretty simple when I write it like that, doesn't it? Not sure why it took me the better part of a month. 🦥

Note that there are still many, many limitations to this feature. Known limitations include:
* Slice names of existing elements are ignored. So, this feature will not help you with those.
* Choice elements with type constraints applied through an OnlyRule will still offer completion items for the excluded types.
* Elements added to a Logical or Resource through an AddElementRule will not be offered for completion. This applies to the Logical or Resource where those new elements are added, anything that uses that Logical or Resource as the Parent, and any Instance of that Logical or Resource.
* No help is provided on a CodeSystem or ValueSet.
* No help is provided on caret paths.

Even with those limitations, the feature is hopefully pretty useful. In addition to providing the paths of elements that are part of a definition's snapshot, this feature also provides paths for:
* Choice element types. For example, on a Profile of [Observation](https://hl7.org/fhir/observation.html), not only is `value[x]` provided, but so are `valueQuantity`, `valueCodeableConcept`, etc.
* Elements not explicitly part of the snapshot, but knowable based on an element's type definition in the project's dependencies. Since most of the types being used will be in a FHIR core package, this works pretty reliably. For example, on a Profile of [Patient](https://hl7.org/fhir/patient.html), not only is `name` provided, but so are `name.given`, `name.family`, etc.