### PR TITLE
FHIR documentation opens page corresponding to project's FHIR version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -473,9 +473,9 @@
             "dev": true
         },
         "camelcase": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true
         },
         "chai": {
@@ -565,9 +565,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -977,9 +977,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+            "version": "1.14.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+            "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
         },
         "fs-extra": {
             "version": "9.1.0",
@@ -1385,32 +1385,32 @@
             }
         },
         "mocha": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-            "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+            "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.2.0",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -1423,9 +1423,9 @@
                     "dev": true
                 },
                 "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -1446,9 +1446,9 @@
                     "dev": true
                 },
                 "glob": {
-                    "version": "7.1.7",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+                    "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1498,9 +1498,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true
         },
         "natural-compare": {
@@ -2033,9 +2033,9 @@
             "dev": true
         },
         "workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "eslint-config-prettier": "^8.1.0",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
-    "mocha": "^9.1.3",
+    "mocha": "^9.2.1",
     "nock": "^13.0.11",
     "prettier": "^2.2.1",
     "typescript": "^4.2.2",

--- a/src/FshCompletionProvider.ts
+++ b/src/FshCompletionProvider.ts
@@ -374,6 +374,7 @@ export class FshCompletionProvider implements CompletionItemProvider {
               }
             })
             .find(version => /current|4\.0\.1|4\.[1-9]\d*.\d+/.test(version));
+          this.fhirVersion = fhirVersion;
           if (!fhirVersion) {
             fhirVersion = '4.0.1';
           } else if (/^4\.[13]\./.test(fhirVersion)) {
@@ -381,7 +382,6 @@ export class FshCompletionProvider implements CompletionItemProvider {
           } else if (!fhirVersion.startsWith('4.0.')) {
             fhirPackage = 'hl7.fhir.r5.core';
           }
-          this.fhirVersion = fhirVersion;
           // try to get dependencies: more or less doing SUSHI's importConfiguration.parseDependencies
           if (parsedConfig.dependencies) {
             parsedDependencies = Object.entries(parsedConfig.dependencies).map(

--- a/src/FshCompletionProvider.ts
+++ b/src/FshCompletionProvider.ts
@@ -63,6 +63,7 @@ export class FshCompletionProvider implements CompletionItemProvider {
   cachePath: string;
   // fsWatcher keeps an eye on the workspace for filesystem events
   fsWatcher: FileSystemWatcher;
+  fhirVersion: string;
 
   constructor(private definitionProvider: FshDefinitionProvider) {
     this.cachePath = path.join(os.homedir(), '.fhir', 'packages');
@@ -380,6 +381,7 @@ export class FshCompletionProvider implements CompletionItemProvider {
           } else if (!fhirVersion.startsWith('4.0.')) {
             fhirPackage = 'hl7.fhir.r5.core';
           }
+          this.fhirVersion = fhirVersion;
           // try to get dependencies: more or less doing SUSHI's importConfiguration.parseDependencies
           if (parsedConfig.dependencies) {
             parsedDependencies = Object.entries(parsedConfig.dependencies).map(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -67,20 +67,35 @@ suite('Extension Test Suite', () => {
 
   suite('#getDocumentationUri', () => {
     test('should return the corresponding specific uri when the input is a FSH entity name', () => {
+      // FSH documentation URLs are not affected by the project's FHIR version
       assert.equal(
-        myExtension.getDocumentationUri('Profile'),
+        myExtension.getDocumentationUri('Profile', null),
         myExtension.SPECIAL_URLS.get('profile')
       );
       assert.equal(
-        myExtension.getDocumentationUri('CodeSystem'),
+        myExtension.getDocumentationUri('CodeSystem', null),
         myExtension.SPECIAL_URLS.get('codesystem')
       );
     });
 
-    test('should return a FHIR documentation uri when the input is not a FSH entity name', () => {
+    test('should return a FHIR documentation uri when the name is not a FSH entity and the FHIR version is not available', () => {
       assert.deepEqual(
-        myExtension.getDocumentationUri('PractitionerRole'),
+        myExtension.getDocumentationUri('PractitionerRole', null),
         vscode.Uri.parse('https://hl7.org/fhir/practitionerrole.html', true)
+      );
+    });
+
+    test('should return a FHIR documentation uri when the name is not a FSH entity and a supported FHIR version is provided', () => {
+      assert.deepEqual(
+        myExtension.getDocumentationUri('Observation', '4.1.0'),
+        vscode.Uri.parse('https://hl7.org/fhir/2021Mar/observation.html', true)
+      );
+    });
+
+    test('should return a FHIR documentation uri when the name is not a FSH entity and an unsupported FHIR version is provided', () => {
+      assert.deepEqual(
+        myExtension.getDocumentationUri('MedicationRequest', '4.6.8'),
+        vscode.Uri.parse('https://hl7.org/fhir/medicationrequest.html', true)
       );
     });
   });


### PR DESCRIPTION
Fixes #34 and completes task [CIMPL-885](https://standardhealthrecord.atlassian.net/browse/CIMPL-885).

FshCompletionProvider stores the FHIR version found in the project's configuration. When opening FHIR documentation, use that FHIR version to open the documentation page corresponding to the configured version. Only versions 4.0.1 and later have their corresponding documentation pages available, as these are the FHIR versions supported by SUSHI. If the FHIR version is unrecognized or unavailable, open the default documentation page for the specified name.

Update a handful of dependencies that npm audit was complaining about.

In addition to the automated tests, I recommend testing by running the extension to observe that the URLs opened will change when you modify `sushi-config.yml` for your project.