### PR TITLE
Updates for SUSHI Build Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Documentation pages can be opened directly from your FSH files. Right-click on t
 
 The extension provides a custom task for running SUSHI on the current workspace. The task will run SUSHI on the workspace, log messages to VS Code's integrated Terminal tab, report any errors or warnings in VS Code's Problems tab, and highlight errors and warnings inline in the FSH file. Selecting an error or warning from the Problems tab will open the file the error is in.
 
-Note that after any errors or warnings are resolve in the FSH, SUSHI must be run through the task to resolve them in the Problems tab and inline in the FSH file.
+Note that after any errors or warnings are resolved in the FSH, SUSHI must be run through the task to resolve them in the Problems tab and inline in the FSH file.
 
-To run the SUSHI Build task, use VS Code's Run Task feature, select 'fsh' and select 'fsh: sushi'. The task can also be run using the keyboard shortcut for running build tasks, which is ⇧⌘B on Mac and Ctrl+Shift+B on Windows.
+To run the SUSHI Build task, use VS Code's Run Task feature. The "Run Task" feature can be accessed in the "Terminal" menu by clicking "Run Task...". When the menu opens in VS Code, select 'fsh' and then select 'sushi'. The task can also be run using the keyboard shortcut for running build tasks, which is ⇧⌘B on Mac and Ctrl+Shift+B on Windows.
 
 Note that you must have SUSHI installed locally in order for the task to run successfully. See [SUSHI Installation instructions](https://fshschool.org/docs/sushi/installation/) for help installing.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "vscode": "^1.39.0"
   },
   "activationEvents": [
-    "onLanguage:fsh"
+    "onLanguage:fsh",
+    "onCommand:workbench.action.tasks.runTask"
   ],
   "main": "./out/extension",
   "categories": [

--- a/src/SushiBuildTaskProvider.ts
+++ b/src/SushiBuildTaskProvider.ts
@@ -25,7 +25,7 @@ export function getSushiBuildTask(): Task {
     TaskScope.Workspace,
     'sushi', // name
     'fsh',
-    new ShellExecution('sushi "${workspaceFolder}"'),
+    new ShellExecution('sushi', ['${workspaceFolder}'], { shellQuoting: { strong: '"' } }),
     '$sushi' // problemMatcher
   );
   sushiBuildTask.presentationOptions = {

--- a/src/test/suite/SushiBuildTaskProvider.test.ts
+++ b/src/test/suite/SushiBuildTaskProvider.test.ts
@@ -13,7 +13,12 @@ suite('SushiBuildTaskProvider', () => {
       assert.equal(task.scope, 2); // TaskScope.Workspace
       assert.equal(task.name, 'sushi');
       assert.equal(task.source, 'fsh');
-      assert.deepEqual(task.execution, new vscode.ShellExecution('sushi "${workspaceFolder}"'));
+      assert.deepEqual(
+        task.execution,
+        new vscode.ShellExecution('sushi', ['${workspaceFolder}'], {
+          shellQuoting: { strong: '"' }
+        })
+      );
       assert.deepEqual(task.problemMatchers, ['$sushi']);
       assert.deepEqual(task.presentationOptions, { clear: true });
       assert.equal(task.group, vscode.TaskGroup.Build);


### PR DESCRIPTION
This PR makes 3 updates based on feedback from Mark. Major credit for this PR goes to @mint-thompson for helping me debug a lot of this and finding some nice solutions!

- Clarify how to find the "Run Task" feature of VS Code through the "Terminal" menu. If anyone has feedback for how to further clarify this, I'm open to any suggestions.
- Update when the extension is activated to include activating when tasks are accessed. This addresses one of the cases Mark ran in to, where if a `.fsh` file is not open in the VS Code window, the extension isn't activated, and no tasks were found. This should prevent this, and it should make sure the SUSHI task is always able to run.
  - To test this, open a FSH project in a VS Code window that does not have any `.fsh` files open. Click "Run Task...", click "fsh". On the published version of the extension, you will see a menu option that says "No fsh tasks found." On this branch, you should see the "sushi" task available.
  - After performing the steps as above and running the SUSHI task, the "Run Task" menu should show "fsh:sushi" as a recently used task. In the published version of the extension, clicking on this task would cause an error popup in the lower right corner of VS Code saying "there is no task provider registered for tasks of type "fsh"". On this branch, using the recently used task should work even if no `.fsh` files have been opened.
- Update how the quoted workspaceFolder is passed in to SUSHI. Previously, the way we had supported it was not working on PowerShell integrated terminals so the path that was passed in to SUSHI wasn't in a format that could handle spaces, so SUSHI truncated the path at the first space it saw. This updates how we put quotes around the workspaceFolder. I believe @mint-thompson and I have tested this on a variety of different shells, but if anyone notices one where a directory path with spaces isn't properly handled, let me know.
  - To test this, open a FSH project inside a directory with spaces and run the SUSHI build command in a PowerShell shell. In the published version of the extension, SUSHI receives a truncated path that ends at the first space and it cannot run SUSHI on the project. This branch should handle spaces properly for all shells.