### PR TITLE
Mapping Id Bug Fix

### DIFF
--- a/snippets/fsh-snippets.json
+++ b/snippets/fsh-snippets.json
@@ -130,7 +130,7 @@
 			"Mapping: $1",
 			"Source: $2",
 			"Target: \"$3\"",
-			"Id: \"$4\"",
+			"Id: $4",
 			"Title: \"$5\"",
 			"Description: \"$6\"",
 			"* $0"


### PR DESCRIPTION
The `Id` keyword in `Mapping`s should not be quoted, but the snippet was putting quotes for the value to be entered into. This just removes the `""`. The functionality of the snippet should still work and you should still be able to enter an `Id` as usual when using the snippet.