### PR TITLE
Add Context keyword

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -29,7 +29,7 @@
       "patterns": [
         {
           "name": "keyword.control.fsh",
-          "match": "\\b(Alias|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
+          "match": "\\b(Alias|Context|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
         },
         {
           "match": "\\b(CodeSystem|Extension|Id|Instance|InstanceOf|Invariant|Logical|Mapping|Parent|Profile|Resource|RuleSet|Source|ValueSet)\\s?(:)\\s+([A-Za-z0-9_.:/-]+)\\b",


### PR DESCRIPTION
Small PR to add the new `Context` keyword to the regular expression for language keywords. I added the examples from the FSH Spec to show how they all look with different types of values after the `Context` keyword. As discussed earlier, we can add additional highlighting and autocomplete features to the values following `Context` later on.

![context](https://github.com/standardhealth/vscode-language-fsh/assets/30803904/3df90d98-e077-4c63-a897-2fa51e62d4df)
