### PR TITLE
Fix R5 Path Completion

### DIFF
--- a/src/FshCompletionProvider.ts
+++ b/src/FshCompletionProvider.ts
@@ -373,7 +373,7 @@ export class FshCompletionProvider implements CompletionItemProvider {
                 return null;
               }
             })
-            .find(version => /current|4\.0\.1|4\.[1-9]\d*.\d+/.test(version));
+            .find(version => /current|4\.0\.1|4\.[1-9]\d*\.\d+|5\.\d+\.\d+/.test(version));
           this.fhirVersion = fhirVersion;
           if (!fhirVersion) {
             fhirVersion = '4.0.1';

--- a/src/test/.fhir/packages/hl7.fhir.r5.core#4.8.2/package/.index.json
+++ b/src/test/.fhir/packages/hl7.fhir.r5.core#4.8.2/package/.index.json
@@ -1,4 +1,0 @@
-{
-    "comment": "This is the index file for FHIR version 4.8.2.",
-    "files": []
-}

--- a/src/test/.fhir/packages/hl7.fhir.r5.core#5.0.0/package/.index.json
+++ b/src/test/.fhir/packages/hl7.fhir.r5.core#5.0.0/package/.index.json
@@ -1,0 +1,4 @@
+{
+    "comment": "This is the index file for FHIR version 5.0.0.",
+    "files": []
+}

--- a/src/test/suite/FshCompletionProvider.test.ts
+++ b/src/test/suite/FshCompletionProvider.test.ts
@@ -1014,8 +1014,8 @@ suite('FshCompletionProvider', () => {
     });
 
     test('should update from the specified version of hl7.fhir.r5.core when there is a SUSHI config', async () => {
-      // create sushi-config.yml with fhirVersion: 4.8.2
-      const configContents = defaultConfig.replace('4.0.1', '4.8.2');
+      // create sushi-config.yml with fhirVersion: 5.0.0
+      const configContents = defaultConfig.replace('4.0.1', '5.0.0');
       const configPath = path.join(
         vscode.workspace.workspaceFolders[0].uri.fsPath,
         'sushi-config.yml'
@@ -1024,7 +1024,7 @@ suite('FshCompletionProvider', () => {
       // update entities using specified version
       instance.cachePath = path.join(TEST_ROOT, '.fhir', 'packages');
       await instance.updateFhirEntities();
-      assert.hasAllKeys(instance.fhirEntities, ['hl7.fhir.r5.core#4.8.2']);
+      assert.hasAllKeys(instance.fhirEntities, ['hl7.fhir.r5.core#5.0.0']);
     });
 
     test('should show an information message when a SUSHI config exists, but specifies a FHIR version not present in the cache', async () => {


### PR DESCRIPTION
This PR fixes the path completion provider for R5. Since this support was originally added before R5 existed, it only supported FHIR versions starting with `4.` -- but now it also allows `5.x.x` versions.

~I also updated Node to version 18, which caused the package-lock.json to be rewritten.~ I originally tried to update to Node 18 as well, but this caused all the Windows tests to fail in GitHub Actions. I tried to fix it, but there were no quick solutions, so I reverted it back to leave this PR as a simple bug fix without updating Node.