### PR TITLE
Add CodeableReference keyword

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -120,7 +120,7 @@
           "match": "(\\(\\s*)(exactly|example|extensible|preferred|required)(\\s*\\))"
         },
         {
-          "begin": "\\b(Reference|Canonical)\\s*\\(",
+          "begin": "\\b(Reference|Canonical|CodeableReference)\\s*\\(",
           "beginCaptures": {
             "0": {
               "name": "keyword.reserved.fsh"


### PR DESCRIPTION
Adds the new CodeableReference keyword to work the same way the `Reference()` and `Canonical()` keywords work, in anticipation of the addition to FSH and SUSHI.