### PR TITLE
Include Characteristics keyword; Update Extension and Logical Snippet

### DIFF
--- a/snippets/fsh-snippets.json
+++ b/snippets/fsh-snippets.json
@@ -24,6 +24,7 @@
 			"Id: ${2:${1/(([A-Z]*)[_]([A-Z]*))|(([A-Z]*[a-z0-9]+)([A-Z]+))|(([A-Z]+)([A-Z0-9])([a-z]))/${2:/downcase}${5:/downcase}${8:/downcase}-${3:/downcase}${6:/downcase}${9:/downcase}$10/g}}",
 			"Title: \"${3:${1/[_]|(([a-z0-9])([A-Z]))|(([A-Z])([A-Z0-9])([a-z]))/$2$5 $3$6$7/g}}\"",
 			"Description: \"$4\"",
+			"Context: $5",
 			"* $0"
 		],
 		"description": "Create a FSH Extension"
@@ -39,6 +40,7 @@
 			"Id: ${3:$1}",
 			"Title: \"${4:${1/[_]|(([a-z0-9])([A-Z]))|(([A-Z])([A-Z0-9])([a-z]))/$2$5 $3$6$7/g}}\"",
 			"Description: \"$5\"",
+			"Characteristics: $6",
 			"* $0"
 		],
 		"description": "Create a FSH Resource"

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -29,7 +29,7 @@
       "patterns": [
         {
           "name": "keyword.control.fsh",
-          "match": "\\b(Alias|Context|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
+          "match": "\\b(Alias|Characteristics|Context|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
         },
         {
           "match": "\\b(CodeSystem|Extension|Id|Instance|InstanceOf|Invariant|Logical|Mapping|Parent|Profile|Resource|RuleSet|Source|ValueSet)\\s?(:)\\s+([A-Za-z0-9_.:/-]+)\\b",


### PR DESCRIPTION
This PR adds the new `Characteristics` keyword to the syntax highlighting regular expression. The codes that follow it will be highlighted as codes, even when in a comma separated list.

Also as part of this PR, I updated the Extension snippet to use the new suggested `Context` keyword. The snippet doesn't insert any `""` since not all uses of the `Context` keyword will be a string. I also updated the Logical snippet to use the new suggested `Characteristics` keyword. I didn't add any options for the values to add after it (similar to `InstanceOf` in the Instance snippet) because there was no way to support adding multiple values, so I figured it was better to just leave it open ended.