### PR TITLE
Add syntax highlight for double-bracketed parameters

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -100,7 +100,7 @@
           "patterns": [
             {
               "name": "string.quoted.other.bracketed.fsh",
-              "begin": "\\[\\[",
+              "begin": "(?<=[^\\\\][,\\(]\\s*)\\[\\[",
               "end": "\\]\\](?=\\s*[,)])"
             },
             {

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -87,7 +87,7 @@
           }
         },
         {
-          "begin": "\\b(insert)\\s+(\\S+)\\s*\\(",
+          "begin": "\\b(insert)\\s+(\\S*?)\\s*\\(",
           "beginCaptures": {
             "1": {
               "name": "keyword.reserved.fsh"
@@ -98,6 +98,11 @@
           },
           "end": "(?<!\\\\)\\)",
           "patterns": [
+            {
+              "name": "string.quoted.other.bracketed.fsh",
+              "begin": "\\[\\[",
+              "end": "\\]\\](?=\\s*[,)])"
+            },
             {
               "name": "variable.parameter.fsh",
               "match": "([^\\s\\),]+)"


### PR DESCRIPTION
Completes task [CIMPL-1098](https://standardhealthrecord.atlassian.net/browse/CIMPL-1098).

The pattern for double-bracketed parameters is within the context of an `insert` rule with parameters, so double-brackets don't get highlighted in other situations. I tested this out with the insert rules with double-bracketed parameters used in SUSHI's `FSHImporter` tests. The lookbehind on the double-bracket `begin` rules is needed to highlight correctly when double-brackets follow an escaped `(` or `,` character:
```
* insert SomeRules(123\, [[oh no]])
```
In this rule, the double-brackets do _not_ indicate a double-bracketed parameter. There is one parameter with value `123, [[oh no]]`.