### PR TITLE
Highlight strings in Context values

### DIFF
--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -35,7 +35,7 @@
           "begin": "\\b(Context)\\s?(:)\\s+",
           "beginCaptures": {
             "1": {
-              "name": "keyword.reserved.fsh"
+              "name": "keyword.control.fsh"
             },
             "2": {
               "name": "keyword.tokens.fsh"

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -29,7 +29,56 @@
       "patterns": [
         {
           "name": "keyword.control.fsh",
-          "match": "\\b(Alias|Characteristics|Context|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
+          "match": "\\b(Alias|Characteristics|Expression|Description|Mixins|Severity|Target|Title|Usage|XPath)(?=\\s*:)\\b"
+        },
+        {
+          "begin": "\\b(Context)\\s?(:)\\s+",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.reserved.fsh"
+            },
+            "2": {
+              "name": "keyword.tokens.fsh"
+            }
+          },
+          "end": "((\"(?:\\\\.|[^\\\\\"])*\")|([^\"][^\\s,]+))\\s+(?!,)",
+          "endCaptures": {
+            "2": {
+              "name": "string.quoted.double.final.fsh"
+            },
+            "3": {
+              "name": "entity.name.path.final.fsh"
+            }
+          },
+          "patterns": [
+            {
+              "name": "string.quoted.double.fsh",
+              "begin": "\"",
+              "end": "\"(\\s*,\\s)",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.tokens.fsh"
+                }
+              },
+              "patterns": [
+                {
+                  "name": "constant.character.escape.fsh",
+                  "match": "\\\\."
+                }
+              ]
+            },
+            {
+              "match": "([^\\s,]+)\\s*(,)\\s*",
+              "captures": {
+                "1": {
+                  "name": "entity.name.path.fsh"
+                },
+                "2": {
+                  "name": "keyword.tokens.fsh"
+                }
+              }
+            }
+          ]
         },
         {
           "match": "\\b(CodeSystem|Extension|Id|Instance|InstanceOf|Invariant|Logical|Mapping|Parent|Profile|Resource|RuleSet|Source|ValueSet)\\s?(:)\\s+([A-Za-z0-9_.:/-]+)\\b",

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -41,7 +41,7 @@
               "name": "keyword.tokens.fsh"
             }
           },
-          "end": "((\"(?:\\\\.|[^\\\\\"])*\")|([^\"][^\\s,]+))\\s+(?!,)",
+          "end": "((\"(?:\\\\.|[^\\\\\"])*\")|([^\"\\s][^\\s,]+))\\s+(?!,)",
           "endCaptures": {
             "2": {
               "name": "string.quoted.double.fsh"
@@ -54,7 +54,7 @@
             {
               "name": "string.quoted.double.fsh",
               "begin": "\"",
-              "end": "\"(\\s*,\\s)",
+              "end": "\"\\s*(,)\\s*",
               "endCaptures": {
                 "1": {
                   "name": "keyword.tokens.fsh"

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -44,10 +44,10 @@
           "end": "((\"(?:\\\\.|[^\\\\\"])*\")|([^\"][^\\s,]+))\\s+(?!,)",
           "endCaptures": {
             "2": {
-              "name": "string.quoted.double.final.fsh"
+              "name": "string.quoted.double.fsh"
             },
             "3": {
-              "name": "entity.name.path.final.fsh"
+              "name": "entity.name.type.fsh"
             }
           },
           "patterns": [
@@ -71,7 +71,7 @@
               "match": "([^\\s,]+)\\s*(,)\\s*",
               "captures": {
                 "1": {
-                  "name": "entity.name.path.fsh"
+                  "name": "entity.name.type.fsh"
                 },
                 "2": {
                   "name": "keyword.tokens.fsh"


### PR DESCRIPTION
Completes task [CIMPL-1114](https://standardhealthrecord.atlassian.net/browse/CIMPL-1114).

Try it out with some [FSH with lots of Context keywords](https://fshschool.org/FSHOnline/#/share/3oF6TfL) to see how you feel about these highlights. FHIRPath strings get the usual double-quote style applied. Other contexts don't get any particular style applied. The `,` token is highlighted, which should be helpful, but might also be distracting? I kind of like it, though.