### PR TITLE
Syntax highlight fixes for quoted codes and aliases after keywords

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/vscode": "^1.39.0",
         "@typescript-eslint/eslint-plugin": "^6.7.5",
         "@typescript-eslint/parser": "^6.7.5",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.9",
         "chai": "^4.3.10",
         "chai-spies": "^1.0.0",
         "eslint": "^8.51.0",
@@ -460,15 +460,15 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=16"
@@ -2928,15 +2928,15 @@
       }
     },
     "@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       }
     },
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,11 +589,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1259,9 +1259,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -3024,11 +3024,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3526,9 +3526,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/vscode": "^1.39.0",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
-    "@vscode/test-electron": "^2.3.3",
+    "@vscode/test-electron": "^2.3.9",
     "chai": "^4.3.10",
     "chai-spies": "^1.0.0",
     "eslint": "^8.51.0",

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -263,8 +263,8 @@
           "end": "'"
         },
         {
-          "name": "constant.numeric.code.fsh",
-          "match": "\\$[^\\s\\\"]*"
+          "name": "string.unquoted.url.fsh",
+          "match": "\\$[^\\s\\#]*"
         },
         {
           "name": "constant.character.escape.fsh",

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -218,7 +218,7 @@
       "name": "url.fsh",
       "patterns": [
         {
-          "match": "\\b(https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&\\/\\/=]*))\\b",
+          "match": "\\b(https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~?&\\/\\/=]*))\\b",
           "captures": {
             "0": {
               "name": "string.unquoted.url.fsh"

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -264,7 +264,7 @@
         },
         {
           "name": "constant.numeric.code.fsh",
-          "match": "\\$[^\\s]*"
+          "match": "\\$[^\\s\\\"]*"
         },
         {
           "name": "constant.character.escape.fsh",

--- a/syntaxes/fsh.tmLanguage.json
+++ b/syntaxes/fsh.tmLanguage.json
@@ -81,7 +81,7 @@
           ]
         },
         {
-          "match": "\\b(CodeSystem|Extension|Id|Instance|InstanceOf|Invariant|Logical|Mapping|Parent|Profile|Resource|RuleSet|Source|ValueSet)\\s?(:)\\s+([A-Za-z0-9_.:/-]+)\\b",
+          "match": "\\b(CodeSystem|Extension|Id|Instance|InstanceOf|Invariant|Logical|Mapping|Parent|Profile|Resource|RuleSet|Source|ValueSet)\\s?(:)\\s+([A-Za-z0-9$_.:/-]+)\\b",
           "captures": {
             "1": {
               "name": "keyword.control.fsh"


### PR DESCRIPTION
Fixes #72 

This PR fixes the issue reported in #72. With the current version of the extension, having a coding with a system that uses an alias and a code that has spaces does not highlight correctly. With this branch, the following rule no longer breaks the syntax highlighting for the rest of the file:

```
* valueCodeableConcept = $test#"example code"
```

I also made a bonus update to an issue that I saw recently. When using an Alias that starts with `$` after a FSH keyword, it wasn't highlighted. If this shouldn't have been highlighted, I can revert this change. With this branch, the following keyword highlight as expected:

```
InstanceOf: $ServiceRequest
```

I checked and neither of these issues appear on FSH Online because it uses slightly different syntax highlighting.

I also ran an `npm audit fix` and committed those changes, and I had to update the `@vscode/test-electron` dependency to get the tests to run again.