### PR TITLE
v1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-language-fsh",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-language-fsh",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-language-fsh",
   "displayName": "FHIR Shorthand",
   "description": "FHIR Shorthand (FSH) Language Support by MITRE",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "author": "The MITRE Corporation",
   "license": "Apache-2.0",
   "publisher": "MITRE-Health",


### PR DESCRIPTION
Small PR to bump the version to v1.16.1. The only change in this version will be the fix to quoted codes with spaces and aliases after keywords, so I figured a patch version was sufficient.

No issues were reported by `npm audit`.