### PR TITLE
New FSH Publisher + v1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-language-fsh",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-language-fsh",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "vscode": "^1.39.0"
+        "vscode": "^1.92.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-language-fsh",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-language-fsh",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-language-fsh",
   "displayName": "FHIR Shorthand",
   "description": "FHIR Shorthand (FSH) Language Support by HL7",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "author": "Health Level Seven International",
   "license": "Apache-2.0",
   "publisher": "FHIR-Shorthand",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-language-fsh",
   "displayName": "FHIR Shorthand",
   "description": "FHIR Shorthand (FSH) Language Support by HL7",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "author": "Health Level Seven International",
   "license": "Apache-2.0",
   "publisher": "FHIR-Shorthand",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.16.1",
   "author": "Health Level Seven International",
   "license": "Apache-2.0",
-  "publisher": "MITRE-Health",
+  "publisher": "FHIR-Shorthand",
   "icon": "images/docs/fsh-icon.png",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/standardhealth/vscode-language-fsh"
   },
   "engines": {
-    "vscode": "^1.39.0"
+    "vscode": "^1.92.0"
   },
   "activationEvents": [
     "onLanguage:fsh",

--- a/src/test/suite/FshCompletionProvider.test.ts
+++ b/src/test/suite/FshCompletionProvider.test.ts
@@ -27,7 +27,7 @@ suite('FshCompletionProvider', () => {
   let definitionInstance: FshDefinitionProvider;
 
   before(() => {
-    extension = vscode.extensions.getExtension('mitre-health.vscode-language-fsh');
+    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-language-fsh');
     instance = extension?.exports.completionProviderInstance as FshCompletionProvider;
     definitionInstance = extension?.exports.definitionProviderInstance as FshDefinitionProvider;
   });

--- a/src/test/suite/FshDefinitionProvider.test.ts
+++ b/src/test/suite/FshDefinitionProvider.test.ts
@@ -16,7 +16,7 @@ suite('FshDefinitionProvider', () => {
   let instance: FshDefinitionProvider;
 
   before(() => {
-    extension = vscode.extensions.getExtension('mitre-health.vscode-language-fsh');
+    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-language-fsh');
     instance = extension?.exports.definitionProviderInstance as FshDefinitionProvider;
   });
 


### PR DESCRIPTION
**Description:** This PR adds the new publisher and bumps the version of the extension.

This branch will be merged into `master` and then can be published to the new publisher.

**Testing Instructions:** Make sure I didn't miss an instance of the old publisher.

I believe I can also just publish the extension to the new publisher since that won't affect the old publisher and current extension. If anyone wants to see that as part of testing, let me know.

**Related Issue:** N/A
