### PR TITLE
Update Extension Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "vscode-language-fsh" extension will be documented in this file.
+All notable changes to the "vscode-fsh" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A language support extension for the FHIR Shorthand (FSH) language.
 ## How to Download
 
 In Visual Studio Code, go to the VS Code Extension Marketplace and download the
-`vscode-language-fsh` extension. Once activated, this extension's features should
+`vscode-fsh` extension. Once activated, this extension's features should
 be automatically implemented.
 
 ## Language Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vscode-language-fsh",
+  "name": "vscode-fsh",
   "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-language-fsh",
+      "name": "vscode-fsh",
       "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-language-fsh",
+  "name": "vscode-fsh",
   "displayName": "FHIR Shorthand",
   "description": "FHIR Shorthand (FSH) Language Support by HL7",
   "version": "1.18.0",
@@ -66,7 +66,7 @@
     },
     "problemMatchers": [
       {
-        "owner": "vscode-language-fsh",
+        "owner": "vscode-fsh",
         "name": "sushi",
         "fileLocation": "absolute",
         "pattern": [

--- a/src/test/suite/FshCompletionProvider.test.ts
+++ b/src/test/suite/FshCompletionProvider.test.ts
@@ -27,7 +27,7 @@ suite('FshCompletionProvider', () => {
   let definitionInstance: FshDefinitionProvider;
 
   before(() => {
-    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-language-fsh');
+    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-fsh');
     instance = extension?.exports.completionProviderInstance as FshCompletionProvider;
     definitionInstance = extension?.exports.definitionProviderInstance as FshDefinitionProvider;
   });

--- a/src/test/suite/FshDefinitionProvider.test.ts
+++ b/src/test/suite/FshDefinitionProvider.test.ts
@@ -16,7 +16,7 @@ suite('FshDefinitionProvider', () => {
   let instance: FshDefinitionProvider;
 
   before(() => {
-    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-language-fsh');
+    extension = vscode.extensions.getExtension('fhir-shorthand.vscode-fsh');
     instance = extension?.exports.definitionProviderInstance as FshDefinitionProvider;
   });
 


### PR DESCRIPTION
**Description:** This PR updates the name of the extension so we can publish it to the new publisher. VS Code Marketplace doesn't allow two extensions to have the same name anymore, so we need to update the name of the extension.

**Testing Instructions:** Make sure I didn't miss any places the name is used.

**Related Issue:** N/A
