### PR TITLE
Update displayName and description + v1.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-fsh",
-  "version": "1.18.0",
+  "version": "1.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-fsh",
-      "version": "1.18.0",
+      "version": "1.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-fsh",
-  "displayName": "FHIR Shorthand",
-  "description": "FHIR Shorthand (FSH) Language Support by HL7",
-  "version": "1.18.0",
+  "displayName": "FHIR Shorthand [DEPRECATED]",
+  "description": "FHIR Shorthand (FSH) Language Support by HL7 [DEPRECATED]",
+  "version": "1.16.2",
   "author": "Health Level Seven International",
   "license": "Apache-2.0",
   "publisher": "FHIR-Shorthand",


### PR DESCRIPTION
**Description:** This just updates the `displayName` and `description` so we can publish the new extension without a display name clash.

**Testing Instructions:** Not much to test really.

**Related Issue:** N/A

**Next steps:** I'm planning to release this to the current extension. It will only change the display name and description. Then I _think_ we will be able to publish the new extension. Once that's published, we'll review #91 and update the extension as previously discussed.
